### PR TITLE
Updated database schema to use utf8mb4

### DIFF
--- a/wiki/src/schema.sql
+++ b/wiki/src/schema.sql
@@ -1,13 +1,13 @@
--- MySQL dump 10.13  Distrib 5.5.43, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 8.0.30, for Linux (x86_64)
 --
 -- Host: localhost    Database: wiki
 -- ------------------------------------------------------
--- Server version	5.5.43-0+deb8u1
+-- Server version	5.5.5-10.5.9-MariaDB-1:10.5.9+maria~focal
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+/*!50503 SET NAMES utf8 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -15,19 +15,22 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
+--
+-- Table structure for table `Images`
+--
 
 DROP TABLE IF EXISTS `Images`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Images` (
   `ID` int(10) NOT NULL AUTO_INCREMENT,
   `Time` int(10) NOT NULL,
   `Score` int(10) NOT NULL,
-  `Account` varchar(32) NOT NULL,
-  `Original URL` varchar(255) NOT NULL,
-  `File` varchar(255) NOT NULL,
+  `Account` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Original URL` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `File` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`ID`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -36,16 +39,16 @@ CREATE TABLE `Images` (
 
 DROP TABLE IF EXISTS `Wiki Searches`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Wiki Searches` (
   `ID` int(10) NOT NULL AUTO_INCREMENT,
   `Time` int(10) NOT NULL,
   `Results` int(10) NOT NULL,
-  `Search` varchar(255) NOT NULL,
-  `IP` varchar(32) NOT NULL,
+  `Search` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `IP` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`ID`),
   KEY `IP` (`IP`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -54,18 +57,18 @@ CREATE TABLE `Wiki Searches` (
 
 DROP TABLE IF EXISTS `Wiki_Accounts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Wiki_Accounts` (
   `ID` int(10) NOT NULL AUTO_INCREMENT,
-  `Name` varchar(64) NOT NULL,
-  `Password` varchar(128) NOT NULL,
-  `Email` varchar(255) NOT NULL,
-  `Verification` varchar(10) NOT NULL,
+  `Name` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Password` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Verification` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
   `Verified` int(1) NOT NULL,
   `EditTime` int(10) NOT NULL,
   PRIMARY KEY (`ID`),
   KEY `Name` (`Name`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -74,7 +77,7 @@ CREATE TABLE `Wiki_Accounts` (
 
 DROP TABLE IF EXISTS `Wiki_Edits`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Wiki_Edits` (
   `ID` int(10) NOT NULL AUTO_INCREMENT,
   `PageID` int(10) NOT NULL,
@@ -82,15 +85,15 @@ CREATE TABLE `Wiki_Edits` (
   `EditTime` int(10) NOT NULL,
   `Size` int(10) NOT NULL,
   `Tags` int(11) NOT NULL,
-  `TagList` varchar(255) NOT NULL,
-  `Name` varchar(32) NOT NULL,
-  `Description` varchar(255) NOT NULL,
-  `Title` varchar(255) NOT NULL,
-  `Content` text NOT NULL,
+  `TagList` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Name` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Description` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Content` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   `Archived` tinyint(1) NOT NULL,
   PRIMARY KEY (`ID`),
   KEY `PageID` (`PageID`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -99,20 +102,20 @@ CREATE TABLE `Wiki_Edits` (
 
 DROP TABLE IF EXISTS `Wiki_Pages`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Wiki_Pages` (
   `ID` int(10) NOT NULL AUTO_INCREMENT,
   `Views` int(11) NOT NULL,
-  `Path` varchar(255) NOT NULL,
-  `Title` varchar(255) NOT NULL,
-  `Content` text NOT NULL,
-  `Edits` text NOT NULL,
+  `Path` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Content` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `Edits` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   `EditTime` int(10) NOT NULL,
   PRIMARY KEY (`ID`),
   KEY `Views` (`Views`),
-  KEY `Path_2` (`Path`),
+  KEY `Path_2` (`Path`(250)),
   FULLTEXT KEY `Path` (`Path`,`Title`,`Content`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -121,17 +124,17 @@ CREATE TABLE `Wiki_Pages` (
 
 DROP TABLE IF EXISTS `Wiki_Tag_Statistics`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Wiki_Tag_Statistics` (
   `statisticsID` int(11) NOT NULL AUTO_INCREMENT,
-  `tag` varchar(64) NOT NULL,
+  `tag` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
   `count` int(11) NOT NULL,
   `views` int(11) NOT NULL,
   `created` datetime NOT NULL,
   `modified` datetime NOT NULL,
   PRIMARY KEY (`statisticsID`),
   UNIQUE KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -140,16 +143,18 @@ CREATE TABLE `Wiki_Tag_Statistics` (
 
 DROP TABLE IF EXISTS `Wiki_Tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Wiki_Tags` (
   `tagID` int(11) NOT NULL AUTO_INCREMENT,
   `pageID` int(11) NOT NULL,
-  `tag` varchar(64) NOT NULL,
+  `tag` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`tagID`),
   KEY `pageID` (`pageID`),
   KEY `tag` (`tag`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
@@ -158,4 +163,4 @@ CREATE TABLE `Wiki_Tags` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2015-09-17 23:48:32
+-- Dump completed on 2023-01-17 14:38:48


### PR DESCRIPTION
We're already running using utf8mb4 on prod, however the schema example file was never updated to reflect these changes.