### PR TITLE
Removed quotes from NULL values in sql queries

### DIFF
--- a/wiki/ban.php
+++ b/wiki/ban.php
@@ -10,12 +10,12 @@ if($_POST)
         $ID = $_POST['id'];
         mysql_query("Update `Wiki_Accounts` set `Verified`='-1' where `ID`='$ID'");
         echo "User banned.<br />";
-        
+
         if($_POST['revert'] == "on")
         {
             $Reverted = array();
             $BadAccount = $ID;
-            
+
             $PageQuery = mysql_query("SELECT `PageID` FROM `Wiki_Edits` WHERE `AccountID`='$BadAccount'");
             while(list($PageID) = mysql_fetch_array($PageQuery))
             {
@@ -30,7 +30,7 @@ if($_POST)
                     mysql_query("UPDATE `Wiki_Pages` SET `EditTime`='$Time',`Title`='$PageTitle',`Content`='$PageContent' WHERE `ID`='$PageID'");
                     $SQLError .= mysql_error();
 
-                    mysql_query("INSERT INTO `Wiki_Edits` VALUES ('NULL', '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$PageName', 'Rachel&#39;s Super Revert: $PageDescription', '$PageTitle', '$PageContent', '')");
+                    mysql_query("INSERT INTO `Wiki_Edits` VALUES (NULL, '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$PageName', 'Rachel&#39;s Super Revert: $PageDescription', '$PageTitle', '$PageContent', '')");
                     $SQLError .= mysql_error();
 
                     mysql_query("UPDATE `Wiki_Accounts` SET `EditTime`='$Time' WHERE `ID`='{$_SESSION['ID']}'");
@@ -41,13 +41,13 @@ if($_POST)
             }
 
             $Count = $Reverted[$PageID];
-            
+
             if($SQLError)
                 echo "<b>Holy SHIT there was a MySQL error.</b>";
             else
                 echo "$Count pages reverted.";
         }
-        
+
         echo "<hr />";
     }
 }

--- a/wiki/index.php
+++ b/wiki/index.php
@@ -133,7 +133,7 @@ else
 
     if(empty($ID))
     {
-        mysql_query("INSERT INTO `Wiki_Accounts` VALUES ('NULL', '$userIP', '', '', '', '0', '')");
+        mysql_query("INSERT INTO `Wiki_Accounts` VALUES (NULL, '$userIP', '', '', '', '0', '')");
         $ID = mysql_insert_id();
     }
 
@@ -275,19 +275,19 @@ switch($Action[0])
                     mysql_query("UPDATE `Wiki_Pages` SET `Title`='$PageTitle',`Content`='$PageContent' WHERE `ID`='$PageID'");
                     $SQLError .= mysql_error();
 
-                    mysql_query("INSERT INTO `Wiki_Edits` VALUES ('NULL', '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$tagCount', '$tagText', '$Name', '$Description', '$PageTitle', '$PageContent', '')");
+                    mysql_query("INSERT INTO `Wiki_Edits` VALUES (NULL, '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$tagCount', '$tagText', '$Name', '$Description', '$PageTitle', '$PageContent', '')");
                     $SQLError .= mysql_error();
 
                     $EditID = mysql_insert_id();
                 }
                 else
                 {
-                    mysql_query("INSERT INTO `Wiki_Pages` VALUES ('NULL', '1', '$Path', '$PageTitle', '$PageContent', '', '')");
+                    mysql_query("INSERT INTO `Wiki_Pages` VALUES (NULL, '1', '$Path', '$PageTitle', '$PageContent', '', '')");
                     $SQLError .= mysql_error();
 
                     $PageID = mysql_insert_id();
 
-                    mysql_query("INSERT INTO `Wiki_Edits` VALUES ('NULL', '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$tagCount', '$tagText', '$Name', '$Description', '$PageTitle', '$PageContent', '')");
+                    mysql_query("INSERT INTO `Wiki_Edits` VALUES (NULL, '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$tagCount', '$tagText', '$Name', '$Description', '$PageTitle', '$PageContent', '')");
                     $SQLError .= mysql_error();
 
                     $EditID = mysql_insert_id();
@@ -498,7 +498,7 @@ SuperNav;
                 mysql_query("UPDATE `Wiki_Pages` SET `EditTime`='$Time',`Title`='$PageTitle',`Content`='$PageContent' WHERE `ID`='$PageID'");
                 $SQLError .= mysql_error();
 
-                //mysql_query("INSERT INTO `Wiki_Edits` VALUES ('NULL', '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$PageName', 'Rachel&#39;s Super Revert: $PageDescription', '$PageTitle', '$PageContent', '')");
+                //mysql_query("INSERT INTO `Wiki_Edits` VALUES (NULL, '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$PageName', 'Rachel&#39;s Super Revert: $PageDescription', '$PageTitle', '$PageContent', '')");
                 //$SQLError .= mysql_error();
 
                 //mysql_query("UPDATE `Wiki_Accounts` SET `EditTime`='$Time' WHERE `ID`='{$_SESSION['ID']}'");
@@ -543,7 +543,7 @@ SuperNav;
             mysql_query("UPDATE `Wiki_Pages` SET `EditTime`='$Time',`Title`='$PageTitle',`Content`='$PageContent' WHERE `ID`='$PageID'");
             $SQLError .= mysql_error();
 
-            mysql_query("INSERT INTO `Wiki_Edits` VALUES ('NULL', '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$PageName', 'Reverted to: $PageDescription', '$PageTitle', '$PageContent', '')");
+            mysql_query("INSERT INTO `Wiki_Edits` VALUES (NULL, '$PageID', '{$_SESSION['ID']}', '$Time', '$Size', '$PageName', 'Reverted to: $PageDescription', '$PageTitle', '$PageContent', '')");
             $SQLError .= mysql_error();
 
             mysql_query("UPDATE `Wiki_Accounts` SET `EditTime`='$Time' WHERE `ID`='{$_SESSION['ID']}'");

--- a/wiki/src/markup/edit.php
+++ b/wiki/src/markup/edit.php
@@ -155,7 +155,7 @@ function edit_replacements($tag, $content)
                 // Make sure the user IP is sanitized
                 $userIP = preg_replace('/[^0-9.]/', '', $userIP);
 
-                mysql_query("Insert into `Images` values ('NULL', '$Time', '', '$userIP', '$Link', 'upload/$Filename.$Extension')");
+                mysql_query("Insert into `Images` values (NULL, '$Time', '', '$userIP', '$Link', 'upload/$Filename.$Extension')");
 
                 $Text = trim("upload/$Filename.$Extension|$Size|$Position|$Border|$Text", '|');
                 return array('tag' => strtolower($tag), 'content' => $Text);
@@ -224,7 +224,7 @@ function edit_replacements($tag, $content)
                 }
 
                 fclose($Disk);
- 
+
                 chmod("upload/$Filename.$Extension", 0644);
 
                 $time = time();
@@ -237,7 +237,7 @@ function edit_replacements($tag, $content)
                 // Make sure the user IP is sanitized
                 $userIP = preg_replace('/[^0-9.]/', '', $userIP);
 
-                mysql_query("Insert into `Images` values ('NULL', '$time', '', '$userIP', '$link', 'upload/$Filename.$Extension')");
+                mysql_query("Insert into `Images` values (NULL, '$time', '', '$userIP', '$link', 'upload/$Filename.$Extension')");
                 $text = trim("upload/$Filename.$Extension|$autoplay|$loop", '|');
 
                 return array('tag' => strtolower($tag), 'content' => $text);

--- a/wiki/upload.php
+++ b/wiki/upload.php
@@ -65,7 +65,7 @@ if($_FILES)
                     return;
 		}
         }
-    
+
         $Filename = uuid();
         while(file_exists("upload/$Filename.$Extension"))
             {
@@ -85,7 +85,7 @@ if($_FILES)
         // Make sure the user IP is sanitized
         $userIP = preg_replace('/[^0-9.]/', '', $userIP);
 
-        mysql_query("Insert into `Images` values ('NULL', '$Time', '', '$userIP', '{$Image['name']}', 'upload/$Filename.$Extension')");
+        mysql_query("Insert into `Images` values (NULL, '$Time', '', '$userIP', '{$Image['name']}', 'upload/$Filename.$Extension')");
 
         if(!empty($_GET['api']))
         {


### PR DESCRIPTION
Fixes type errors in modern versions of MySQL / MariaDB

```
Incorrect integer value: 'NULL' for column `wiki`.`Wiki_Pages`.`ID` at row 1
Incorrect integer value: 'NULL' for column `wiki`.`Wiki_Edits`.`ID` at row 1
```
