### PR TITLE
Change error reporting to hide notices / warnings

### DIFF
--- a/wwwroot/functions.php
+++ b/wwwroot/functions.php
@@ -1,6 +1,6 @@
 <?php
 
-error_reporting(E_ALL ^ E_NOTICE);
+error_reporting(E_ERROR | E_PARSE);
 include("src/mysql.php");
 
 function Redirect($URL, $Time=2)

--- a/wwwroot/index.php
+++ b/wwwroot/index.php
@@ -1,6 +1,6 @@
 <?php
 
-error_reporting(E_ALL ^ E_NOTICE);
+error_reporting(E_ERROR | E_PARSE);
 session_start();
 
 require_once('src/config.php');


### PR DESCRIPTION
Ran into some issues after the php v8 upgrade where warnings about undefined variables were clogging up the request headers.

Seems to mostly impact large pages like the news page which have a lot of content. 

![Screenshot from 2024-03-09 03-32-48](https://github.com/wetfish/wiki/assets/1670549/7662394a-a0a0-440c-a283-b1069ac040fe)

![Screenshot from 2024-03-09 03-35-58](https://github.com/wetfish/wiki/assets/1670549/001a0c7b-b02f-4762-9c56-09a882afe058)
