### PR TITLE
added mov and webp support

### DIFF
--- a/wwwroot/notgallery.php
+++ b/wwwroot/notgallery.php
@@ -16,7 +16,7 @@ function the($Thing)
 		$Path = pathinfo($Thing);
 		$Extension = $Path['extension'];
 
-		if(preg_match('{jpe?g|gif|png}i', $Extension))
+		if(preg_match('{jpe?g|gif|png|webp}i', $Extension))
 			return 'Image';
 	}
 
@@ -62,9 +62,11 @@ function ResizeImage($Filename, $Thumbnail, $Size)
 		case "image/jpeg":
 			$Image = @ImageCreateFromJpeg($Filename);
 			break;
+		case "image/webp":
+			$Image = @ImageCreateFromWebp($Filename);
 	}
 
-	if($ImageData[2] == IMAGETYPE_GIF or $ImageData[2]  == IMAGETYPE_PNG)
+	if($ImageData[2] == IMAGETYPE_GIF or $ImageData[2]  == IMAGETYPE_PNG or $ImageData[2] == IMAGETYPE_WEBP)
 	{
 		$TransIndex = imagecolortransparent($Image);
 
@@ -85,7 +87,7 @@ function ResizeImage($Filename, $Thumbnail, $Size)
 
 		}
 		// Always make a transparent background color for PNGs that don't have one allocated already
-		elseif ($ImageData[2] == IMAGETYPE_PNG)
+		elseif ($ImageData[2] == IMAGETYPE_PNG or $ImageData[2] == IMAGETYPE_WEBP)
 		{
 
 			// Turn off transparency blending (temporarily)
@@ -110,6 +112,9 @@ function ResizeImage($Filename, $Thumbnail, $Size)
 			break;
 		case "image/png":
 			@ImagePng($NewImage, $Thumbnail);
+			break;
+		case "image/webp":
+			@ImageWebp($NewImage, $Thumbnail);
 			break;
 		case "image/jpeg":
 			@ImageJpeg($NewImage, $Thumbnail);

--- a/wwwroot/src/markup/edit.php
+++ b/wwwroot/src/markup/edit.php
@@ -108,11 +108,17 @@ function edit_replacements($tag, $content)
                     case "image/png":
                         $Extension = "png";
                         break;
+                    case "image/webp":
+                        $Extension = "webp";
+                        break;
                     case "video/webm":
                         $Extension = "webm";
                         break;
                     case "video/mp4":
                         $Extension = "mp4";
+                        break;
+                    case "video/quicktime";
+                        $Extension = "mov";
                         break;
                     case "video/ogg":
                         $Extension = "ogv";
@@ -121,7 +127,7 @@ function edit_replacements($tag, $content)
                         $Extension = "svg";
                         break;
                     default:
-                        return "$Mime: Unsupported format! Please use: jpg, gif, png, webm, gifv, mp4, or ogv";
+                        return "$Mime: Unsupported format! Please use: jpg, gif, png, webp, webm, gifv, mp4, mov, or ogv";
                 }
 
                 while(file_exists("upload/$Filename.$Extension"))

--- a/wwwroot/src/markup/view.php
+++ b/wwwroot/src/markup/view.php
@@ -261,7 +261,7 @@ function view_replacements($tag, $content)
                 $path = pathinfo($Link);
 
                 // If a video extension was used
-                if(preg_match('/^(webm|mp4|ogv)$/i', $path['extension']))
+                if(preg_match('/^(webm|mp4|ogv|mov)$/i', $path['extension']))
                 {
                     // Output a special html5 player that behaves like a gif
                     $options = array

--- a/wwwroot/upload.php
+++ b/wwwroot/upload.php
@@ -26,6 +26,7 @@ if($_FILES)
     else
     {
         $Mime = mime_content_type($Image['tmp_name']);
+        error_log($Mime);
         switch($Mime){
             case "image/jpg":
                 $Extension = "jpg";
@@ -39,6 +40,9 @@ if($_FILES)
             case "image/png":
                 $Extension = "png";
                 break;
+            case "image/webp":
+                $Extension = "webp";
+                break;
             case "audio/mpeg":
             case "audio/mp3":
                 $Extension = "mp3";
@@ -49,6 +53,9 @@ if($_FILES)
                 break;
             case "video/mp4":
                 $Extension = "mp4";
+                break;
+            case "video/quicktime":
+                $Extension = "mov";
                 break;
             case "audio/midi":
             case "audio/xmidi":


### PR DESCRIPTION
was relatively simple, just a few things to check, added webp's to the thumbnail logic, and tested with transparancy and without and have confirmed this on my local instance. mov was generated with ffmpeg from an mp4 file. also works and displays with a default html5 video player

![image](https://github.com/wetfish/wiki/assets/13123926/99cc7712-aeac-4fa3-9dd4-dd497ee94d14)
![image](https://github.com/wetfish/wiki/assets/13123926/3cc90113-518f-45a5-8cdd-e929b7bb0ea0)
![image](https://github.com/wetfish/wiki/assets/13123926/b6bb90dc-093c-413a-ab9b-c7edf3fe3d69)


