### PR TITLE
Alert the user if they are leaving unsaved changes in the editor

### DIFF
--- a/wwwroot/src/js/wiki.js
+++ b/wwwroot/src/js/wiki.js
@@ -157,10 +157,21 @@ $(document).ready(function()
             if (!confirm('You have unsaved changes. Are you sure you want to leave?')) {
                 e.preventDefault();
             } else {
+                // Override function to make sure it doesn't fire anyways
+                $(wnidow).on('beforeunload', function (e) {});
                 changed = false;
             }
         }
     });
+
+    $(window).on('beforeunload', function(e) {
+        if (hasChanges(changed, formData)) {
+            var confirmationMessage = 'You have unsaved changes. Are you sure you want to leave?';
+            (e || window.event).returnValue = confirmationMessage;
+            return confirmationMessage;
+        }
+    });
+
 
     $('#TheInternet').on('change input', function () {
         changed = true;

--- a/wwwroot/src/js/wiki.js
+++ b/wwwroot/src/js/wiki.js
@@ -131,23 +131,58 @@ function buildQuery(input)
     return output.join('&');
 }
 
+function hasChanges(changed, formData) {
+    var Form = document.getElementById('TheInternet');
+    return changed || (new FormData(Form) !== formData);
+}
+
 $(document).ready(function()
 {
     // Populate saved name from local storage
     var name = localStorage.getItem('name');
+    // Check if the title is "Preview:", which means changes are likely pending
+    var title = document.querySelector('div.title');
+    var changed = title && title.textContent.trim().startsWith('Preview:');
+    // Stash the form so we can use it to compare for changes later
+    var Form = document.getElementById('TheInternet');
+    var formData = new FormData(Form);
 
     if(name)
     {
         $('#Name').value(name);
     }
 
-    $('#TheInternet').on('submit', function() {
-        var Form = document.getElementById('TheInternet');
-        Form.action = Form.action + 'edit';
+    $('a').on('click', function(e) {
+        if (hasChanges(changed, formData)) {
+            if (!confirm('You have unsaved changes. Are you sure you want to leave?')) {
+                e.preventDefault();
+            } else {
+                changed = false;
+            }
+        }
+    });
 
+    $('#TheInternet').on('change input', function () {
+        changed = true;
+    });
+
+    $('#TheInternet').on('submit', function() {
+        // Update our stashed form data, and remove the `changed` guard
+        var Form = document.getElementById('TheInternet');
+        formData = new FormData(Form);
+        changed = false;
+
+        Form.action = Form.action + 'edit';
         // Save current name in local storage
         var name = $('#Name').value();
         localStorage.setItem('name', name);
+        return true;
+    });
+
+    // Preview should justwerk
+    $('input[value="Preview"]').on('click', function(e) {
+        changed = false;
+        return true;
     });
 
     $('.navbox').on('click', function(event)

--- a/wwwroot/src/js/wiki.js
+++ b/wwwroot/src/js/wiki.js
@@ -158,7 +158,7 @@ $(document).ready(function()
                 e.preventDefault();
             } else {
                 // Override function to make sure it doesn't fire anyways
-                $(wnidow).on('beforeunload', function (e) {});
+                $(window).on('beforeunload', function (e) {});
                 changed = false;
             }
         }


### PR DESCRIPTION
This creates a confirm dialog on clicking any navigation link while edits are still active.

 - This currently doesn't alert if a back/forward navigation occurs
 
<img width="1260" alt="Screenshot 2024-09-28 at 14 17 52" src="https://github.com/user-attachments/assets/30410f8a-70b8-487a-8952-121d43d84f4f">

